### PR TITLE
Silence known Pages action warning

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -72,4 +72,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
+        env:
+          # deploy-pages v5 bundles a dependency that triggers this known Node 24 warning.
+          NODE_OPTIONS: --disable-warning=DEP0040
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- suppress only Node warning code DEP0040 for the deploy-pages@v5 step
- retain the required deploy-pages v5 action and all other runtime warnings

## Rationale

The successful production run exposed a known upstream deploy-pages v5 warning from its bundled @actions/artifact dependency. The v5 tag and current main SHA are identical, so there is no fixed upstream revision to pin yet. This targeted Node 24 option removes only DEP0040 until actions/deploy-pages#413 or #434 is fixed.

## Validation

- workflow YAML syntax passed
- local Node reproduction confirmed DEP0040 appears without the option and is absent with the targeted option
- Hugo Extended 0.164.0 strict production build passed with zero warnings/deprecations and counts 21/41/7/71/2

Follow-up for #10.